### PR TITLE
Remove Amsterdam Light Festival aanbod section

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,22 +144,6 @@
     </div>
   </section>
 
-  <!-- Amsterdam Light Festival aanbod -->
-  <section class="py-16 md:py-20">
-    <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
-      <h2 class="text-2xl md:text-3xl font-semibold">Amsterdam Light Festival aanbod</h2>
-      <p class="mt-4">Dit winterseizoen varen we weer uit tijdens het Amsterdam Light Festival. Speciaal voor vrienden van de sloep bieden wij:</p>
-      <ul class="mt-6 space-y-2">
-        <li>💶 €59,95 p.p. all-in – inclusief warme glühwein, verse erwtensoep, frisdrank én warme dekentjes</li>
-        <li>🕰️ 1,5 uur varen</li>
-        <li>👥 max. 11 personen</li>
-        <li>📅 27 nov – 18 jan | ⏰ 17:30, 19:30 of 21:30</li>
-      </ul>
-      <p class="mt-6">Met schipper en hostess aan boord die iedereen voorzien van drinken en soep.</p>
-      <p class="mt-2 font-medium">Het zit altijd snel vol → stuur me een appje om te reserveren 👉 <a href="https://wa.me/31624928211" class="underline">06 24 92 82 11</a></p>
-    </div>
-  </section>
-
   <!-- Gallery (second Swiper) -->
   <section id="gallery" class="py-10 md:py-14 border-y border-black/5">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- remove Amsterdam Light Festival offer section from landing page

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c8020e811c832ca96cebe4a1109066