### PR TITLE
Add slide-specific overlays to hero carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       <nav class="flex items-center gap-3">
         <a href="#how" class="hidden md:inline-block text-sm hover:underline">Hoe boeken</a>
         <a href="#gallery" class="hidden md:inline-block text-sm hover:underline">Foto's</a>
-        <a href="#book" class="hidden md:inline-block text-sm hover:underline">Boeken</a>
+        <a href="#boeken" class="hidden md:inline-block text-sm hover:underline">Boeken</a>
         <a
           href="https://wa.me/31624928211?text=Boekingsaanvraag%20ALF25%20–%20Hallo!%20Ik%20wil%20graag%20boeken."
           class="inline-flex items-center rounded-2xl bg-black px-4 py-2 text-white text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-black"
@@ -52,22 +52,50 @@
   <section id="hero" class="relative">
     <div class="swiper h-[80vh]">
       <div class="swiper-wrapper">
-        <!-- Slideshow images -->
-        <div class="swiper-slide">
+        <!-- Slideshow images with overlay content -->
+        <div class="swiper-slide relative">
           <img src="public/images/Openboat.jpg" alt="Open boat on the Amsterdam canals"
                class="w-full h-full object-cover" loading="eager" />
+          <div class="absolute inset-0 flex items-center justify-center text-center">
+            <div class="bg-black/50 px-6 py-4 rounded-2xl max-w-xl">
+              <h1 class="text-3xl md:text-5xl font-bold text-white">Privé boottocht · Amsterdam Light Festival</h1>
+              <p class="mt-2 text-lg text-white/90">Exclusief voor jouw groep · max. 11 personen</p>
+              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+            </div>
+          </div>
         </div>
-        <div class="swiper-slide">
+        <div class="swiper-slide relative">
           <img src="public/images/Solstice_ArtistImpression_ALF13.jpg" alt="Lichtkunst – Solstice"
                class="w-full h-full object-cover" loading="lazy" />
+          <div class="absolute inset-0 flex items-center justify-center text-center">
+            <div class="bg-black/50 px-6 py-4 rounded-2xl max-w-xl">
+              <h1 class="text-3xl md:text-5xl font-bold text-white">Warme dekens, glühwein & erwtensoep</h1>
+              <p class="mt-2 text-lg text-white/90">Geniet met vrienden van lichtkunst op de grachten</p>
+              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+            </div>
+          </div>
         </div>
-        <div class="swiper-slide">
+        <div class="swiper-slide relative">
           <img src="public/images/amsterdam-light-festival-2021-route.jpg" alt="Route Amsterdam Light Festival"
                class="w-full h-full object-cover" loading="lazy" />
+          <div class="absolute inset-0 flex items-center justify-center text-center">
+            <div class="bg-black/50 px-6 py-4 rounded-2xl max-w-xl">
+              <h1 class="text-3xl md:text-5xl font-bold text-white">Met schipper én hostess aan boord</h1>
+              <p class="mt-2 text-lg text-white/90">Iedereen verzorgd met drankjes & soep</p>
+              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+            </div>
+          </div>
         </div>
-        <div class="swiper-slide">
+        <div class="swiper-slide relative">
           <img src="public/images/de-sculpturen-boven-de-herengracht-zijn-gemaakt-van-gevlochten.webp" alt="Sculpturen Herengracht"
                class="w-full h-full object-cover" loading="lazy" />
+          <div class="absolute inset-0 flex items-center justify-center text-center">
+            <div class="bg-black/50 px-6 py-4 rounded-2xl max-w-xl">
+              <h1 class="text-3xl md:text-5xl font-bold text-white">€59,95 p.p. all-in · 90 min</h1>
+              <p class="mt-2 text-lg text-white/90">Tijdsloten 17:30 · 19:30 · 21:30</p>
+              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+            </div>
+          </div>
         </div>
       </div>
       <!-- Controls -->
@@ -76,27 +104,7 @@
       <div class="swiper-button-next"></div>
     </div>
 
-    <!-- Hero content overlay -->
-    <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/50 to-black/10"></div>
-    <div class="absolute inset-0 flex items-end md:items-center">
-      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-10 md:pb-0">
-        <div class="pointer-events-auto max-w-xl md:max-w-2xl lg:max-w-3xl text-white">
-          <h1 class="text-4xl md:text-6xl font-semibold leading-tight">Canal Cruise & Light Festival</h1>
-          <p class="mt-3 text-lg md:text-xl opacity-95">Sail through Amsterdam’s shimmering canals during the annual Light Festival.</p>
-          <p class="mt-1 text-base md:text-lg font-medium">Jij regelt de mensen, wij de rest.</p>
-          <div class="mt-6 flex flex-wrap items-center gap-3">
-            <a
-              href="#book"
-              class="inline-flex items-center rounded-2xl bg-white text-black px-6 py-3 text-base font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
-              >Nu boeken</a>
-            <a
-              href="tel:+31624928211"
-              class="inline-flex items-center rounded-2xl bg-black/70 text-white px-6 py-3 text-base font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
-              >Bel ons</a>
-          </div>
-        </div>
-      </div>
-    </div>
+    <!-- Hero overlay removed in favor of per-slide overlays -->
   </section>
 
   <!-- Highlights / USP -->
@@ -187,7 +195,7 @@
   </section>
 
   <!-- Booking block -->
-  <section id="book" class="py-16 md:py-20 bg-neutral-50">
+  <section id="boeken" class="py-16 md:py-20 bg-neutral-50">
     <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
       <h2 class="text-2xl md:text-3xl font-semibold">Boekingsaanvraag</h2>
       <p class="mt-2 text-black/70">We bewaren geen gegevens; het formulier maakt een WhatsApp- of e‑mailbericht voor je klaar.</p>
@@ -286,7 +294,7 @@
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row items-center justify-between gap-4">
       <p class="text-sm text-black/60">© <span id="year"></span> ALF25 – Amsterdam</p>
       <div class="flex items-center gap-4 text-sm">
-        <a href="#book" class="hover:underline">Boeken</a>
+        <a href="#boeken" class="hover:underline">Boeken</a>
         <a href="https://instagram.com/" target="_blank" rel="noopener" class="hover:underline">Instagram</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Display unique overlay text and booking button on each hero slide
- Remove old global hero overlay and update anchors to `#boeken`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c803484450832c8433c982325d658f