### PR TITLE
Enforce 11 person limit in booking form

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,6 +384,14 @@
         }
       }
 
+      const numPeople = parseInt(data.people, 10);
+      if (!Number.isInteger(numPeople) || numPeople < 1 || numPeople > 11) {
+        feedback.classList.remove('sr-only');
+        feedback.className = 'mt-3 text-sm text-red-600';
+        feedback.textContent = 'Maximaal 11 personen.';
+        return;
+      }
+
       const msg = buildMessage(data);
       openWhatsAppOrFallback(msg);
     });


### PR DESCRIPTION
## Summary
- validate booking form to reject submissions with more than 11 people

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c804203974832cb9eabc6bb571f7d1