### PR TITLE
Improve hero slideshow transition fluidity

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,9 +369,9 @@
     const heroSwiper = new Swiper('#hero .swiper', {
       loop: true,
       effect: 'fade',
-      speed: 1000,
+      speed: 1500,
       fadeEffect: { crossFade: true },
-      autoplay: { delay: 1500, disableOnInteraction: false },
+      autoplay: { delay: 4000, disableOnInteraction: false },
       pagination: { el: '#hero .swiper-pagination', clickable: true },
       navigation: { nextEl: '#hero .swiper-button-next', prevEl: '#hero .swiper-button-prev' },
       keyboard: { enabled: true }


### PR DESCRIPTION
## Summary
- Slow down header slideshow autoplay to create smoother transitions
- Lengthen fade speed for more fluid slide changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c805fe9f78832c9873199857a18204