### PR TITLE
Remove outdated festival promotion snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,22 +162,6 @@
     </div>
   </section>
 
- codex/add-smooth-scroll-reveal-for-new-info
-  <!-- Amsterdam Light Festival aanbod -->
-  <section class="py-16 md:py-20" data-reveal>
-    <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
-      <h2 class="text-2xl md:text-3xl font-semibold">Amsterdam Light Festival aanbod</h2>
-      <p class="mt-4">Dit winterseizoen varen we weer uit tijdens het Amsterdam Light Festival. Speciaal voor vrienden van de sloep bieden wij:</p>
-      <ul class="mt-6 space-y-2">
-        <li>💶 €59,95 p.p. all-in – inclusief warme glühwein, verse erwtensoep, frisdrank én warme dekentjes</li>
-        <li>🕰️ 1,5 uur varen</li>
-        <li>👥 max. 11 personen</li>
-        <li>📅 27 nov – 18 jan | ⏰ 17:30, 19:30 of 21:30</li>
-      </ul>
-      <p class="mt-6">Met schipper en hostess aan boord die iedereen voorzien van drinken en soep.</p>
-      <p class="mt-2 font-medium">Het zit altijd snel vol → stuur me een appje om te reserveren 👉 <a href="https://wa.me/31624928211" class="underline">06 24 92 82 11</a></p>
-
- codex/add-amsterdam-light-festival-section
   <!-- Amsterdam Light Festival – Aanbod -->
   <section id="aanbod" class="py-12">
     <div class="mx-auto max-w-4xl px-4">


### PR DESCRIPTION
## Summary
- remove outdated Amsterdam Light Festival promotion block from landing page

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8066d39dc832c8e9d842636b98501