### PR TITLE
Replace USP cards with bullet list

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,26 +117,18 @@
     <!-- Hero overlay removed in favor of per-slide overlays -->
   </section>
 
-  <!-- Highlights / USP -->
+  <!-- Aan boord inbegrepen -->
   <section class="py-16 md:py-20" data-reveal>
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-      <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-        <li class="p-6 rounded-2xl ring-1 ring-black/5">
-          <p class="text-sm uppercase tracking-wide text-black/60">Capaciteit</p>
-          <p class="mt-2 text-xl font-semibold">Tot <span class="whitespace-nowrap">11 personen</span></p>
-        </li>
-        <li class="p-6 rounded-2xl ring-1 ring-black/5">
-          <p class="text-sm uppercase tracking-wide text-black/60">Comfort</p>
-          <p class="mt-2 text-xl font-semibold">Toilet aan boord</p>
-        </li>
-        <li class="p-6 rounded-2xl ring-1 ring-black/5">
-          <p class="text-sm uppercase tracking-wide text-black/60">Sfeer</p>
-          <p class="mt-2 text-xl font-semibold">Kussens & speakers</p>
-        </li>
-        <li class="p-6 rounded-2xl ring-1 ring-black/5">
-          <p class="text-sm uppercase tracking-wide text-black/60">Tafel</p>
-          <p class="mt-2 text-xl font-semibold">Grote borreltafel</p>
-        </li>
+      <h2 class="text-2xl md:text-3xl font-semibold">Aan boord inbegrepen</h2>
+      <ul class="mt-6 space-y-3 text-lg text-black/80">
+        <li class="flex items-start"><span class="mr-3 text-black">•</span> Tot 11 personen</li>
+        <li class="flex items-start"><span class="mr-3 text-black">•</span> Toilet aan boord</li>
+        <li class="flex items-start"><span class="mr-3 text-black">•</span> Kussens & speakers</li>
+        <li class="flex items-start"><span class="mr-3 text-black">•</span> Grote borreltafel</li>
+        <li class="flex items-start"><span class="mr-3 text-black">•</span> Verse erwtensoep</li>
+        <li class="flex items-start"><span class="mr-3 text-black">•</span> Warme glühwein</li>
+        <li class="flex items-start"><span class="mr-3 text-black">•</span> Frisdrank inbegrepen</li>
       </ul>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- streamline onboard features section with minimalist bullet list including all amenities

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8078c75f0832c8227fbaa88aaaae1