### PR TITLE
Remove slideshow arrows and speed up autoplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,10 +130,8 @@
         </div>
       </div>
 
-      <!-- Controls -->
+      <!-- Pagination -->
       <div class="swiper-pagination"></div>
-      <div class="swiper-button-prev"></div>
-      <div class="swiper-button-next"></div>
     </div>
   </section>
 
@@ -311,9 +309,8 @@
       effect: 'fade',
       speed: 1200,
       fadeEffect: { crossFade: true },
-      autoplay: { delay: 3800, disableOnInteraction: false, pauseOnMouseEnter: true },
+      autoplay: { delay: 2000, disableOnInteraction: false, pauseOnMouseEnter: true },
       pagination: { el: '#hero .swiper-pagination', clickable: true },
-      navigation: { nextEl: '#hero .swiper-button-next', prevEl: '#hero .swiper-button-prev' },
       keyboard: { enabled: true }
     });
 
@@ -325,7 +322,6 @@
       spaceBetween: 16,
       breakpoints: { 640:{slidesPerView:2}, 1024:{slidesPerView:3} },
       pagination: { el: '#gallery .swiper-pagination', clickable: true },
-      navigation: { nextEl: '#gallery .swiper-button-next', prevEl: '#gallery .swiper-button-prev' },
       keyboard: { enabled: true }
     });
 


### PR DESCRIPTION
## Summary
- remove navigation buttons from the hero slideshow
- set the hero slideshow to advance every 2 seconds
- drop unused gallery navigation config

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c834c75810832c9baafd5da885747e