### PR TITLE
Update WhatsApp booking number

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         <a href="#how" class="hidden md:inline-block text-sm hover:underline">Hoe boeken</a>
         <a href="#boeken" class="hidden md:inline-block text-sm hover:underline">Boeken</a>
         <a
-          href="https://wa.me/31624928211?text=Boekingsaanvraag%20ALF25%20%E2%80%93%20Hallo!%20Ik%20wil%20graag%20boeken."
+          href="https://wa.me/31624978211?text=Boekingsaanvraag%20ALF25%20%E2%80%93%20Hallo!%20Ik%20wil%20graag%20boeken."
           class="inline-flex items-center rounded-2xl bg-black px-4 py-2 text-white text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-black"
         >WhatsApp boeken</a>
       </nav>
@@ -282,7 +282,7 @@
     <div class="mx-auto max-w-7xl px-4 pb-4">
       <div class="mb-safe rounded-2xl bg-white/95 backdrop-blur ring-1 ring-black/10 shadow-sm">
         <div class="grid grid-cols-3 divide-x divide-black/10">
-          <a href="https://wa.me/31624928211?text=Boekingsaanvraag%20ALF25" class="py-3 text-center font-semibold">WhatsApp</a>
+          <a href="https://wa.me/31624978211?text=Boekingsaanvraag%20ALF25" class="py-3 text-center font-semibold">WhatsApp</a>
           <a href="tel:+31624978211" class="py-3 text-center font-semibold">Bel</a>
           <a href="mailto:maxenmatthijs25@gmail.com?subject=Boekingsaanvraag%20ALF25" class="py-3 text-center font-semibold">E‑mail</a>
         </div>
@@ -370,7 +370,7 @@
     function encode(str) { return encodeURIComponent(str); }
 
     function openWhatsAppOrFallback(msg) {
-      const waURL = `https://wa.me/31624928211?text=${encode(msg)}`;
+      const waURL = `https://wa.me/31624978211?text=${encode(msg)}`;
       const mailURL = `mailto:bookings@canalstartup.nl?subject=Boekingsaanvraag%20ALF25&body=${encode(msg)}`;
 
       // Update fallback link for accessibility


### PR DESCRIPTION
## Summary
- update all WhatsApp booking links to use the new phone number `+31 6 2497 8211`

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c86803300c832caeb2d77ec76b36ca