### PR TITLE
Add smooth scroll animation for Boek nu buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,6 +315,43 @@
       keyboard: { enabled: true }
     });
 
+    // Slow scroll for Boek nu links
+    const boekLinks = document.querySelectorAll('a[href="#boeken"]');
+    const boekenSection = document.getElementById('boeken');
+
+    function easeInOutQuad(t) {
+      return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+    }
+
+    function slowScrollToBoeken(event) {
+      if (!boekenSection) return;
+      event.preventDefault();
+
+      const startY = window.scrollY || window.pageYOffset;
+      const targetY = boekenSection.getBoundingClientRect().top + startY;
+      const distance = targetY - startY;
+      const duration = 1200;
+      let startTime = null;
+
+      function step(timestamp) {
+        if (!startTime) startTime = timestamp;
+        const elapsed = timestamp - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+        const eased = easeInOutQuad(progress);
+        window.scrollTo(0, startY + distance * eased);
+
+        if (elapsed < duration) {
+          requestAnimationFrame(step);
+        } else {
+          window.history.replaceState(null, '', '#boeken');
+        }
+      }
+
+      requestAnimationFrame(step);
+    }
+
+    boekLinks.forEach((link) => link.addEventListener('click', slowScrollToBoeken));
+
 
     const gallerySwiper = new Swiper('#gallery .swiper', {
       loop: true,


### PR DESCRIPTION
## Summary
- intercept clicks on Boek nu anchors and animate a gentle scroll to the bookings section
- apply a custom ease-in-out animation so visitors can clearly see the extra content below the fold

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c90aef57e8832cb43fe3d72ee843b3