### PR TITLE
Adjust scroll indicator positioning for safe areas

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,13 +35,14 @@
     /* Hero scroll indicator */
     .scroll-indicator {
       position: absolute;
-      bottom: 1.5rem;
+      bottom: calc(1.5rem + env(safe-area-inset-bottom));
       left: 50%;
       transform: translateX(-50%);
       font-size: 2rem;
       color: rgba(255, 255, 255, 0.8);
       text-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
       pointer-events: none;
+      z-index: 10;
     }
 
     .scroll-indicator .chevron {


### PR DESCRIPTION
## Summary
- adjust the hero scroll indicator's bottom offset to account for iOS safe area insets
- add a small z-index so the scroll indicator stays above the swiper slides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c935c908cc832cad48986c32d6c91b