### PR TITLE
Adjust hero slider pagination styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,52 @@
         transform: rotate(90deg);
       }
     }
+
+    /* Hero pagination adjustments */
+    #hero .swiper {
+      position: relative;
+    }
+
+    #hero .swiper-pagination {
+      position: absolute;
+      top: 50%;
+      bottom: auto;
+      left: 50%;
+      transform: translate(-50%, calc(-50% - 6rem));
+      width: auto;
+      display: flex;
+      gap: 0.75rem;
+      z-index: 30;
+    }
+
+    #hero .swiper-pagination-bullet {
+      width: 14px;
+      height: 14px;
+      margin: 0;
+      border-radius: 9999px;
+      opacity: 1;
+      background-color: rgba(255, 255, 255, 0.65);
+      transition: transform 0.3s ease, background-color 0.3s ease;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+    }
+
+    #hero .swiper-pagination-bullet-active {
+      background-color: #fff;
+      transform: scale(1.25);
+      box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+    }
+
+    @media (max-width: 640px) {
+      #hero .swiper-pagination {
+        transform: translate(-50%, calc(-50% - 4.5rem));
+        gap: 0.5rem;
+      }
+
+      #hero .swiper-pagination-bullet {
+        width: 12px;
+        height: 12px;
+      }
+    }
   </style>
 </head>
 <body class="bg-white text-black antialiased">


### PR DESCRIPTION
## Summary
- repositioned the hero slider pagination above the overlay copy
- enlarged the pagination bullets and restyled them as white dots for better readability

## Testing
- not run (static HTML update)


------
https://chatgpt.com/codex/tasks/task_e_68c937c93754832ca64b42b0101ab8d7