### PR TITLE
Add favicon SVG links for Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
   <meta name="description" content="Canal Cruise & Amsterdam Light Festival – gezellig, strak en modern. Jij regelt de mensen, wij de rest. Boek direct via WhatsApp of e‑mail." />
   <title>ALF25 – Canal Cruise & Light Festival</title>
 
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  <link rel="mask-icon" href="favicon.svg" color="#0ea5e9" />
+
   <!-- Tailwind CSS (CDN) -->
   <script src="https://cdn.tailwindcss.com"></script>
   <script>


### PR DESCRIPTION
## Summary
- add favicon.svg as the default favicon
- register the SVG as Safari's mask icon so it appears in the browser search bar

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c93dbc01e4832c8c6e091fe64f73c6