### PR TITLE
Voeg logo toe aan navigatie

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,15 @@
   <!-- Sticky top nav -->
   <header class="sticky top-0 z-50 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-black/5">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
-      <a href="#hero" class="font-semibold tracking-tight text-xl">ALF25</a>
+      <a href="#hero" class="flex items-center gap-2 font-semibold tracking-tight text-xl">
+        <img
+          src="logo_with_spacing.svg"
+          alt="ALF25 logo"
+          class="h-9 w-auto"
+          decoding="async"
+        />
+        <span>ALF25</span>
+      </a>
       <nav class="flex items-center gap-3">
         <a href="#how" class="hidden md:inline-block text-sm hover:underline">Hoe boeken</a>
         <a


### PR DESCRIPTION
## Summary
- plaats het logo `logo_with_spacing.svg` links van de ALF25-tekst in de topnavigatie
- zorg voor flexibele uitlijning tussen het logo en het label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c942076568832ca6a92a39a786ac37