### PR TITLE
Add social sharing meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,18 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Canal Cruise & Amsterdam Light Festival – gezellig, strak en modern. Jij regelt de mensen, wij de rest. Boek direct via WhatsApp of e‑mail." />
+  <!-- Open Graph / WhatsApp / Facebook -->
+  <meta property="og:title" content="ALF25 – Canal Cruise & Light Festival" />
+  <meta property="og:description" content="Gezellig, strak en modern · Jij regelt de mensen, wij de rest · Boek direct via WhatsApp of e-mail." />
+  <meta property="og:image" content="https://matthijshart.github.io/AmsterdamLightFestival/public/share/alf25-share.png" />
+  <meta property="og:url" content="https://matthijshart.github.io/AmsterdamLightFestival/" />
+  <meta property="og:type" content="website" />
+
+  <!-- Twitter / X -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="ALF25 – Canal Cruise & Light Festival" />
+  <meta name="twitter:description" content="Gezellig, strak en modern · Jij regelt de mensen, wij de rest · Boek direct via WhatsApp of e-mail." />
+  <meta name="twitter:image" content="https://matthijshart.github.io/AmsterdamLightFestival/public/share/alf25-share.png" />
   <title>ALF25 – Canal Cruise & Light Festival</title>
 
   <link rel="icon" type="image/svg+xml" href="favicon_fixed.svg" />


### PR DESCRIPTION
## Summary
- add Open Graph metadata for ALF25 page
- add Twitter card metadata pointing to the public share image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c944d48dac832cbf1ff4b2a3750e12