### PR TITLE
Scroll WhatsApp button to booking section

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
         </a>
         <a
           id="nav-whatsapp-book"
-          href="https://wa.me/31624978211?text=Boekingsaanvraag%20ALF25%20%E2%80%93%20Hallo!%20Ik%20wil%20graag%20boeken."
+          href="#boeken"
           class="inline-flex items-center rounded-2xl bg-black px-4 py-2 text-white text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-black"
         >WhatsApp boeken</a>
       </nav>
@@ -571,27 +571,18 @@
     peopleInput?.addEventListener('input', updatePrice);
 
     const navBooksLink = document.getElementById('nav-books-link');
-    navBooksLink?.addEventListener('click', (event) => {
+    const navWhatsAppButton = document.getElementById('nav-whatsapp-book');
+
+    function scrollToBooking(event) {
       event.preventDefault();
       document.getElementById('boeken')?.scrollIntoView({ behavior: 'smooth' });
       if (typeof history.replaceState === 'function') {
         history.replaceState(null, '', window.location.pathname);
       }
-    });
+    }
 
-    const navWhatsAppButton = document.getElementById('nav-whatsapp-book');
-    navWhatsAppButton?.addEventListener('click', (event) => {
-      event.preventDefault();
-      document.getElementById('boeken')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-
-      const waUrl = navWhatsAppButton.getAttribute('href');
-      if (!waUrl) return;
-
-      const newWindow = window.open(waUrl, '_blank', 'noopener');
-      if (!newWindow) {
-        setTimeout(() => { window.location.href = waUrl; }, 600);
-      }
-    });
+    navBooksLink?.addEventListener('click', scrollToBooking);
+    navWhatsAppButton?.addEventListener('click', scrollToBooking);
 
     form?.addEventListener('submit', (e) => {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- Anchor "WhatsApp boeken" now links to the booking section instead of WhatsApp.
- Use shared handler so both top navigation links smooth-scroll to the booking form.

## Testing
- `npm test` *(fails: package.json not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c945424a2c832cbbfce2ec68073121