### PR TITLE
Add event period under header logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,14 +162,18 @@
   <!-- Sticky top nav -->
   <header class="sticky top-0 z-50 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-black/5">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
-      <a href="#hero" class="flex items-center gap-2 font-semibold tracking-tight text-xl">
-        <img
-          src="logo_with_spacing.svg"
-          alt="ALF25 logo"
-          class="h-9 w-auto"
-          decoding="async"
-        />
-        <span>ALF25</span>
+      <a href="#hero" class="flex flex-col items-start font-semibold tracking-tight">
+        <div class="flex items-center gap-2 text-xl">
+          <img
+            src="logo_with_spacing.svg"
+            alt="ALF25 logo"
+            class="h-9 w-auto"
+            decoding="async"
+          />
+          <span>ALF25</span>
+        </div>
+        <!-- Nieuw: periode onder ALF25 -->
+        <span class="text-sm text-black/70">27 nov – 18 jan</span>
       </a>
       <nav class="flex items-center gap-3">
         <a href="#how" class="hidden md:inline-block text-sm hover:underline">Hoe boeken</a>


### PR DESCRIPTION
## Summary
- stack the navigation logo vertically to allow additional copy below the wordmark
- display the festival period 27 nov – 18 jan under the ALF25 label in the top navigation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c95ca33378832c94004a1a7ef47632