### PR TITLE
Add announcement bar above navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,8 +159,12 @@
   </style>
 </head>
 <body class="bg-white text-black antialiased">
+  <!-- Announcement bar -->
+  <div class="w-full bg-black/90 text-white/80 text-center text-xs py-1.5 fixed top-0 z-50">
+    Bij regen: kosteloos annuleren of verplaatsen
+  </div>
   <!-- Sticky top nav -->
-  <header class="sticky top-0 z-50 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-black/5">
+  <header class="sticky top-[28px] z-40 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-black/5">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
       <a href="#hero" class="flex flex-col items-start font-semibold tracking-tight">
         <div class="flex items-center gap-2 text-xl">


### PR DESCRIPTION
## Summary
- add a fixed announcement bar to show the rain cancellation policy
- offset the sticky header to display beneath the new announcement bar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c960bd0c30832cacc0c949df9c5330