### PR TITLE
Clarify minimum group size messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
           <div class="absolute inset-0 flex items-center justify-center text-center p-4">
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h1 class="text-3xl md:text-5xl font-bold text-white">Privé boottocht · Amsterdam Light Festival</h1>
-              <p class="mt-2 text-lg text-white/90">Exclusief voor jouw groep · max. 11 personen</p>
+              <p class="mt-2 text-lg text-white/90">Exclusief voor jouw groep · 6-11 personen</p>
               <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
@@ -295,7 +295,7 @@
       <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
         <li class="p-6 rounded-2xl ring-1 ring-black/5">
           <p class="text-sm uppercase tracking-wide text-black/60">Capaciteit</p>
-          <p class="mt-2 text-xl font-semibold">Tot <span class="whitespace-nowrap">11 personen</span></p>
+          <p class="mt-2 text-xl font-semibold"><span class="whitespace-nowrap">6-11 personen</span></p>
         </li>
         <li class="p-6 rounded-2xl ring-1 ring-black/5">
           <p class="text-sm uppercase tracking-wide text-black/60">Comfort</p>
@@ -351,7 +351,7 @@
           </div>
           <div class="rounded-xl bg-neutral-50 p-4 ring-1 ring-black/5">
             <p class="text-sm text-black/60">Groep</p>
-            <p class="text-lg font-semibold">max. 11 personen</p>
+            <p class="text-lg font-semibold">6-11 personen</p>
           </div>
           <div class="rounded-xl bg-neutral-50 p-4 ring-1 ring-black/5">
             <p class="text-sm text-black/60">Periode</p>
@@ -369,7 +369,7 @@
         <span class="inline-block mt-4 rounded-full bg-black text-white px-4 py-1 font-medium">All-in €59,95 p.p.</span>
         <ul class="mt-6 space-y-3 text-lg text-black/80">
           <li class="flex items-start"><span class="mr-3 text-black">•</span> 90 minuten varen</li>
-          <li class="flex items-start"><span class="mr-3 text-black">•</span> max. 11 personen</li>
+          <li class="flex items-start"><span class="mr-3 text-black">•</span> 6-11 personen</li>
           <li class="flex items-start"><span class="mr-3 text-black">•</span> Tijdsloten: 17:30 · 19:30 · 21:30</li>
           <li class="flex items-start"><span class="mr-3 text-black">•</span> Warme glühwein, verse erwtensoep & frisdrank inbegrepen</li>
           <li class="flex items-start"><span class="mr-3 text-black">•</span> Warme dekentjes aan boord</li>
@@ -389,7 +389,7 @@
             </select>
           </div>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <input class="rounded-xl border border-black/10 px-4 py-3" id="people" type="number" inputmode="numeric" pattern="[0-9]*" min="1" max="11" name="people" placeholder="Aantal personen*" required>
+            <input class="rounded-xl border border-black/10 px-4 py-3" id="people" type="number" inputmode="numeric" pattern="[0-9]*" min="6" max="11" name="people" placeholder="Aantal personen*" required>
             <input class="rounded-xl border border-black/10 px-4 py-3" id="phone" name="phone" placeholder="Telefoon of e-mail*" required>
           </div>
           <p id="total-price" class="text-sm text-black/70 hidden"></p>
@@ -425,7 +425,7 @@
         </details>
         <details class="group rounded-2xl ring-1 ring-black/5 p-5">
           <summary class="cursor-pointer font-medium">Hoe groot mag de groep zijn?</summary>
-          <div class="mt-2 text-black/80">Tot 11 personen. Kleinere groepen zijn ook welkom.</div>
+          <div class="mt-2 text-black/80">Tussen 6 en 11 personen.</div>
         </details>
         <details class="group rounded-2xl ring-1 ring-black/5 p-5">
           <summary class="cursor-pointer font-medium">Wat als het regent?</summary>


### PR DESCRIPTION
## Summary
- update hero tagline and capacity highlights to state a 6-11 person group size
- adjust aanbod section, booking bullets, and FAQ answer to reflect the 6-11 person requirement
- enforce a minimum of six guests in the booking form by setting the number field to accept only 6-11

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68c964c6b208832cafcae0abfb99cac1