### PR TITLE
Enable sticky contact buttons to scroll to booking section

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,14 +183,14 @@
         <a href="#how" class="hidden md:inline-block text-sm hover:underline">Hoe boeken</a>
         <a
           id="nav-books-link"
-          href="#boeken"
+          href="#booking"
           class="hidden md:inline-block text-sm hover:underline"
         >
           Boeken
         </a>
         <a
           id="nav-whatsapp-book"
-          href="#boeken"
+          href="#booking"
           class="inline-flex items-center rounded-2xl bg-black px-4 py-2 text-white text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-black"
         >WhatsApp boeken</a>
       </nav>
@@ -208,7 +208,7 @@
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h1 class="text-3xl md:text-5xl font-bold text-white">Privé boottocht · Amsterdam Light Festival</h1>
               <p class="mt-2 text-lg text-white/90">Exclusief voor jouw groep · 6-11 personen</p>
-              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+              <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
         </div>
@@ -219,7 +219,7 @@
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h2 class="text-3xl md:text-5xl font-bold text-white">Warme dekens, glühwein &amp; erwtensoep</h2>
               <p class="mt-2 text-lg text-white/90">Geniet met vrienden van lichtkunst op de grachten</p>
-              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+              <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
         </div>
@@ -230,7 +230,7 @@
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h2 class="text-3xl md:text-5xl font-bold text-white">Met schipper én hostess aan boord</h2>
               <p class="mt-2 text-lg text-white/90">Iedereen verzorgd met drankjes &amp; soep</p>
-              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+              <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
         </div>
@@ -241,7 +241,7 @@
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h2 class="text-3xl md:text-5xl font-bold text-white">€59,95 p.p. all-in · 90 min</h2>
               <p class="mt-2 text-lg text-white/90">Tijdsloten 17:30 · 19:30 · 21:30</p>
-              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+              <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
         </div>
@@ -252,7 +252,7 @@
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h2 class="text-3xl md:text-5xl font-bold text-white">Intiem, gezellig, écht Amsterdams</h2>
               <p class="mt-2 text-lg text-white/90">Kleine groepen · geen massatoerisme</p>
-              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+              <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
         </div>
@@ -263,7 +263,7 @@
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h2 class="text-3xl md:text-5xl font-bold text-white">Comfort aan boord</h2>
               <p class="mt-2 text-lg text-white/90">Kussens, speakers en grote borreltafel</p>
-              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+              <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
         </div>
@@ -274,7 +274,7 @@
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h2 class="text-3xl md:text-5xl font-bold text-white">Boek direct via WhatsApp</h2>
               <p class="mt-2 text-lg text-white/90">Snel vol — reserveer je plek vandaag</p>
-              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+              <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
         </div>
@@ -290,7 +290,7 @@
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h2 class="text-3xl md:text-5xl font-bold text-white">27 november t/m 18 januari</h2>
               <p class="mt-2 text-lg text-white/90">Vier het Amsterdam Light Festival met jouw groep</p>
-              <a href="#boeken" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
+              <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
         </div>
@@ -377,7 +377,7 @@
 
 
   <!-- Gecombineerde sectie: Aanbod + Boekingsaanvraag -->
-  <section id="boeken" class="py-16 md:py-20 bg-neutral-50">
+  <section id="booking" class="py-16 md:py-20 bg-neutral-50">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-2 gap-12">
       <!-- Info blok (aanbod) -->
       <div>
@@ -460,11 +460,16 @@
     <div class="mx-auto max-w-7xl px-4 pb-4">
       <div class="mb-safe rounded-2xl bg-white/95 backdrop-blur ring-1 ring-black/10 shadow-sm">
         <div class="grid grid-cols-3 divide-x divide-black/10">
-          <a href="https://wa.me/31624978211?text=Boekingsaanvraag%20ALF25" class="py-3 text-center font-semibold">WhatsApp</a>
+          <a
+            href="#booking"
+            class="py-3 text-center font-semibold"
+            data-scroll-method="scrollIntoView"
+          >WhatsApp</a>
           <a href="tel:+31624978211" class="py-3 text-center font-semibold">Bel</a>
           <a
-            href="mailto:maxenmatthijs25@gmail.com?subject=Boekingsaanvraag%20ALF25&body=Ik%20wil%20graag%20een%20vaartocht%20boeken%20tijdens%20het%20Amsterdam%20Light%20Festival%20op%20%5Bdatum%5D%20om%20%5Btijd%5D%20met%20%5Baantal%5D%20personen."
+            href="#booking"
             class="py-3 text-center font-semibold"
+            data-scroll-method="scrollIntoView"
           >E‑mail</a>
         </div>
       </div>
@@ -476,7 +481,7 @@
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row items-center justify-between gap-4">
       <p class="text-sm text-black/60">© <span id="year"></span> ALF25 – Amsterdam</p>
       <div class="flex items-center gap-4 text-sm">
-        <a href="#boeken" class="hover:underline">Boeken</a>
+        <a href="#booking" class="hover:underline">Boeken</a>
         <a href="https://instagram.com/" target="_blank" rel="noopener" class="hover:underline">Instagram</a>
       </div>
     </div>
@@ -497,19 +502,20 @@
     });
 
     // Slow scroll for Boek nu links
-    const boekLinks = document.querySelectorAll('a[href="#boeken"]');
-    const boekenSection = document.getElementById('boeken');
+    const bookingSection = document.getElementById('booking');
+    const slowBookingLinks = document.querySelectorAll('a[href="#booking"]:not([data-scroll-method="scrollIntoView"])');
+    const scrollIntoViewButtons = document.querySelectorAll('[data-scroll-method="scrollIntoView"]');
 
     function easeInOutQuad(t) {
       return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
     }
 
-    function slowScrollToBoeken(event) {
-      if (!boekenSection) return;
+    function slowScrollToBooking(event) {
+      if (!bookingSection) return;
       event.preventDefault();
 
       const startY = window.scrollY || window.pageYOffset;
-      const targetY = boekenSection.getBoundingClientRect().top + startY;
+      const targetY = bookingSection.getBoundingClientRect().top + startY;
       const distance = targetY - startY;
       const duration = 1200;
       let startTime = null;
@@ -532,7 +538,15 @@
       requestAnimationFrame(step);
     }
 
-    boekLinks.forEach((link) => link.addEventListener('click', slowScrollToBoeken));
+    slowBookingLinks.forEach((link) => link.addEventListener('click', slowScrollToBooking));
+
+    scrollIntoViewButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        if (!bookingSection) return;
+        event.preventDefault();
+        bookingSection.scrollIntoView({ behavior: "smooth" });
+      });
+    });
 
 
     const gallerySwiper = new Swiper('#gallery .swiper', {


### PR DESCRIPTION
## Summary
- rename the booking section and related links to use the `#booking` anchor
- update the sticky WhatsApp and e-mail buttons to trigger a smooth scroll into the booking area
- adjust the smooth scroll helper to skip the sticky buttons and add a `scrollIntoView` handler

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9c2a2c078832cbe9c03644368f84c