### PR TITLE
Hide aanbod section on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
  
 
   <!-- Amsterdam Light Festival – Aanbod -->
-  <section id="aanbod" class="py-12">
+  <section id="aanbod" class="hidden py-12 md:block">
     <div class="mx-auto max-w-4xl px-4">
       <div class="rounded-2xl ring-1 ring-black/5 p-6 md:p-8 bg-white">
         <div class="flex items-center justify-between gap-4 flex-wrap">


### PR DESCRIPTION
## Summary
- hide the aanbod section on small screens using Tailwind utility classes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbae227594832c889ae8c75783014e