### PR TITLE
Improve booking form total price visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,8 +421,8 @@
             <input class="rounded-xl border border-black/10 px-4 py-3" id="people" type="number" inputmode="numeric" pattern="[0-9]*" min="6" max="11" name="people" placeholder="Aantal personen*" required>
             <input class="rounded-xl border border-black/10 px-4 py-3" id="phone" name="phone" placeholder="Telefoon of e-mail*" required>
           </div>
-          <p id="total-price" class="text-sm text-black/70 hidden"></p>
           <textarea class="rounded-xl border border-black/10 px-4 py-3" id="message" name="message" rows="3" placeholder="Opmerkingen (optioneel)"></textarea>
+          <p id="total-price" class="hidden mt-3 text-lg font-semibold text-black"></p>
           <div class="flex flex-wrap gap-3 items-center">
             <button type="submit" class="rounded-2xl bg-black text-white px-6 py-3 font-semibold">WhatsApp reserveren</button>
             <a


### PR DESCRIPTION
## Summary
- move the total price element so it appears just above the WhatsApp CTA and give it the bold booking form styling
- keep the total price hidden by default while still revealing it once a people count is entered

## Testing
- not run (HTML change only)

------
https://chatgpt.com/codex/tasks/task_e_68cbaf421db4832c97c6693ad9583886