### PR TITLE
Add discount code support to booking form

### DIFF
--- a/index.html
+++ b/index.html
@@ -422,6 +422,11 @@
             <input class="rounded-xl border border-black/10 px-4 py-3" id="phone" name="phone" placeholder="Telefoon of e-mail*" required>
           </div>
           <p id="total-price" class="text-sm text-black/70 hidden"></p>
+          <input 
+            class="rounded-xl border border-black/10 px-4 py-3" 
+            id="discount" 
+            name="discount" 
+            placeholder="Kortingscode (optioneel)">
           <textarea class="rounded-xl border border-black/10 px-4 py-3" id="message" name="message" rows="3" placeholder="Opmerkingen (optioneel)"></textarea>
           <div class="flex flex-wrap gap-3 items-center">
             <button type="submit" class="rounded-2xl bg-black text-white px-6 py-3 font-semibold">WhatsApp reserveren</button>
@@ -591,6 +596,14 @@
     const dateInput = document.getElementById('date');
     const totalPriceEl = document.getElementById('total-price');
     const pricePerPerson = 59.95;
+    const discountInput = document.getElementById('discount');
+    let discountActive = false;
+
+    // Geldige kortingscodes
+    const discountCodes = {
+      'HGH': 0.15,     // 15% korting
+      'EVA25': 0.25    // 25% korting
+    };
     const minDate = dateInput?.getAttribute('min');
     const maxDate = dateInput?.getAttribute('max');
 
@@ -656,8 +669,19 @@
     function updatePrice() {
       const count = Number(peopleInput.value);
       if (count > 0) {
-        const total = count * pricePerPerson;
-        totalPriceEl.textContent = `Totaal: ${formatCurrency(total)}`;
+        let total = count * pricePerPerson;
+        discountActive = false;
+
+        // Check kortingscode (ongeacht hoofdletters)
+        const code = discountInput?.value.trim().toUpperCase();
+        if (discountCodes[code]) {
+          const korting = discountCodes[code];
+          total = total * (1 - korting);
+          discountActive = true;
+          totalPriceEl.innerHTML = `<strong>Totaalprijs: ${formatCurrency(total)}</strong> <span class="text-green-600">(${korting * 100}% korting toegepast)</span>`;
+        } else {
+          totalPriceEl.textContent = `Totaalprijs: ${formatCurrency(total)}`;
+        }
         totalPriceEl.classList.remove('hidden');
       } else {
         totalPriceEl.classList.add('hidden');
@@ -675,6 +699,7 @@
 
     peopleInput?.addEventListener('input', handlePeopleInput);
     peopleInput?.addEventListener('blur', handlePeopleInput);
+    discountInput?.addEventListener('input', updatePrice);
     if (peopleInput) handlePeopleInput();
 
     form?.addEventListener('submit', (e) => {
@@ -688,7 +713,12 @@
         message: document.getElementById('message').value.trim()
       };
 
-      data.total = pricePerPerson * Number(data.people);
+      let totalPrice = pricePerPerson * Number(data.people);
+      const appliedCode = discountInput?.value.trim().toUpperCase();
+      if (discountCodes[appliedCode]) {
+        totalPrice = totalPrice * (1 - discountCodes[appliedCode]);
+      }
+      data.total = totalPrice;
 
       // Simple validation
       const required = ['name','phone','people','date','time'];


### PR DESCRIPTION
## Summary
- add an optional discount code input above the message field in the booking form
- update pricing logic to handle HGH and EVA25 discount codes and show applied savings
- ensure the submitted total reflects any discount applied

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbafd8d208832c91583b57436eb08e