### PR TITLE
Fix aanbod section nesting and visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
  
 
   <!-- Amsterdam Light Festival – Aanbod -->
-  <section id="aanbod" class="hidden py-12 md:block">
+  <section id="aanbod" class="hidden md:block py-12">
     <div class="mx-auto max-w-4xl px-4">
       <div class="rounded-2xl ring-1 ring-black/5 p-6 md:p-8 bg-white">
         <div class="flex items-center justify-between gap-4 flex-wrap">
@@ -387,6 +387,10 @@
             <p class="text-lg font-semibold">27 nov – 18 jan</p>
           </div>
         </div>
+
+      </div>
+    </div>
+  </section>
 
 
   <!-- Gecombineerde sectie: Aanbod + Boekingsaanvraag -->


### PR DESCRIPTION
## Summary
- ensure the #aanbod section uses `hidden md:block` so it only disappears on small screens
- close the #aanbod container so the #booking section stays separate and visible on every device

## Testing
- not run (HTML-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cbb1a5d23c832ca72864f769dff65b