### PR TITLE
Move booking total price above call to action

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,17 +427,16 @@
             <input class="rounded-xl border border-black/10 px-4 py-3" id="phone" name="phone" placeholder="Telefoon of e-mail*" required>
           </div>
 
-          <p id="total-price" class="text-sm text-black/70 hidden"></p>
-          <input 
-            class="rounded-xl border border-black/10 px-4 py-3" 
-            id="discount" 
-            name="discount" 
+          <input
+            class="rounded-xl border border-black/10 px-4 py-3"
+            id="discount"
+            name="discount"
             placeholder="Kortingscode (optioneel)">
 
-
           <textarea class="rounded-xl border border-black/10 px-4 py-3" id="message" name="message" rows="3" placeholder="Opmerkingen (optioneel)"></textarea>
+          <!-- Totaalprijs -->
           <p id="total-price" class="hidden mt-3 text-lg font-semibold text-black"></p>
-          <div class="flex flex-wrap gap-3 items-center">
+          <div class="flex flex-wrap gap-3 items-center mt-2">
             <button type="submit" class="rounded-2xl bg-black text-white px-6 py-3 font-semibold">WhatsApp reserveren</button>
             <a
               id="fallback-email"


### PR DESCRIPTION
## Summary
- move the booking total price element to sit directly above the WhatsApp and email call-to-action buttons
- adjust button group spacing to match the new layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbb5a12fa8832cbf72d686639871d7