### PR TITLE
Update booking time slot options

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
           <div class="absolute inset-0 flex items-center justify-center text-center p-4">
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h2 class="text-3xl md:text-5xl font-bold text-white">€59,95 p.p. all-in · 90 min</h2>
-              <p class="mt-2 text-lg text-white/90">Starttijden 17:30 · 19:30</p>
+              <p class="mt-2 text-lg text-white/90">Tijdsloten 17:30-19:00 · 19:30-21:00</p>
               <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
@@ -405,7 +405,7 @@
           <li class="flex items-start"><span class="mr-3 text-black">•</span> 27 nov t/m 18 jan</li>
           <li class="flex items-start"><span class="mr-3 text-black">•</span> 90 minuten varen</li>
           <li class="flex items-start"><span class="mr-3 text-black">•</span> 6-11 personen</li>
-          <li class="flex items-start"><span class="mr-3 text-black">•</span> Tijdsloten: 17:30 · 19:30</li>
+          <li class="flex items-start"><span class="mr-3 text-black">•</span> Tijdsloten: 17:30-19:00 · 19:30-21:00</li>
           <li class="flex items-start"><span class="mr-3 text-black">•</span> Warme glühwein, verse erwtensoep & frisdrank inbegrepen</li>
           <li class="flex items-start"><span class="mr-3 text-black">•</span> Warme dekentjes aan boord</li>
           <li class="flex items-start"><span class="mr-3 text-black">•</span> Met schipper & hostess</li>
@@ -437,7 +437,7 @@
             <div class="flex flex-col gap-1">
               <select class="rounded-xl border border-black/10 px-4 py-3" id="time" name="time" required>
                 <option value="">Kies tijdslot</option>
-                <option>17:30</option><option>19:30</option>
+                <option>17:30-19:00</option><option>19:30-21:00</option>
               </select>
               <p id="time-error" class="hidden text-sm text-red-600" data-error-for="time">Kies een tijdslot</p>
             </div>


### PR DESCRIPTION
## Summary
- update displayed time slot ranges to reflect the full 90-minute sailing windows
- adjust booking form select options to match the updated time slot ranges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd30496fe083329f0afa2e2401eeae