### PR TITLE
Remove email booking option

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Canal Cruise & Amsterdam Light Festival 27 nov 2025 - 18 jan 2026 – met verse soep en glühwein. Boek direct via WhatsApp of e‑mail." />
+  <meta name="description" content="Canal Cruise & Amsterdam Light Festival 27 nov 2025 - 18 jan 2026 – met verse soep en glühwein. Boek direct via WhatsApp." />
   <!-- Open Graph / WhatsApp / Facebook -->
   <meta property="og:title" content="Canal Cruise & Light Festival 27 nov 2025 - 18 jan 2026" />
-  <meta property="og:description" content="Gezellig met verse soep en glühwein · Jij regelt de mensen, wij de rest · Boek direct via WhatsApp of e-mail." />
+  <meta property="og:description" content="Gezellig met verse soep en glühwein · Jij regelt de mensen, wij de rest · Boek direct via WhatsApp." />
   <meta property="og:image" content="alf25-share.png" />
   <meta property="og:url" content="https://matthijshart.github.io/AmsterdamLightFestival/" />
   <meta property="og:type" content="website" />
@@ -14,7 +14,7 @@
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="A.L.F.25 – Canal Cruise & Light Festival" />
-  <meta name="twitter:description" content="Gezellig met verse soep, glühwein en warme dekens · Jij regelt de mensen, wij de rest · Boek direct via WhatsApp of e-mail." />
+  <meta name="twitter:description" content="Gezellig met verse soep, glühwein en warme dekens · Jij regelt de mensen, wij de rest · Boek direct via WhatsApp." />
   <meta name="twitter:image" content="https://matthijshart.github.io/AmsterdamLightFestival/public/share/alf25-share.png" />
   <title>A.L.F.25 – Canal Cruise & Light Festival</title>
 
@@ -468,11 +468,6 @@
           <p id="total-price" class="hidden mt-3 text-lg font-semibold text-black"></p>
           <div class="flex flex-wrap gap-3 items-center mt-2">
             <button type="submit" class="rounded-2xl bg-black text-white px-6 py-3 font-semibold">WhatsApp reserveren</button>
-            <a
-              id="fallback-email"
-              href="mailto:bookings@canalstartup.nl?subject=Boekingsaanvraag%20ALF25&body=Ik%20wil%20graag%20een%20vaartocht%20boeken%20tijdens%20het%20Amsterdam%20Light%20Festival%20op%20%5Bdatum%5D%20om%20%5Btijd%5D%20met%20%5Baantal%5D%20personen."
-              class="rounded-2xl bg-white ring-1 ring-black/10 px-6 py-3 font-semibold"
-            >of e‑mail</a>
           </div>
           <p id="form-feedback" class="mt-3 text-sm text-black/60">Het zit snel vol — stuur je voorkeursdatum en tijdslot mee.</p>
         </form>
@@ -517,18 +512,13 @@
   <div class="fixed inset-x-0 bottom-0 z-40 md:hidden">
     <div class="mx-auto max-w-7xl px-4 pb-4">
       <div class="mb-safe rounded-2xl bg-white/95 backdrop-blur ring-1 ring-black/10 shadow-sm">
-        <div class="grid grid-cols-3 divide-x divide-black/10">
+        <div class="grid grid-cols-2 divide-x divide-black/10">
           <a
             href="#booking"
             class="py-3 text-center font-semibold"
             data-scroll-method="scrollIntoView"
           >WhatsApp</a>
           <a href="tel:+31653802957" class="py-3 text-center font-semibold">Bel</a>
-          <a
-            href="#booking"
-            class="py-3 text-center font-semibold"
-            data-scroll-method="scrollIntoView"
-          >E‑mail</a>
         </div>
       </div>
     </div>
@@ -628,10 +618,9 @@
     // Footer year
     document.getElementById('year').textContent = new Date().getFullYear();
 
-    // Booking form -> WhatsApp (fallback mailto)
+    // Booking form -> WhatsApp
     const form = document.getElementById('booking-form');
     const feedback = document.getElementById('form-feedback');
-    const fallbackEmail = document.getElementById('fallback-email');
     const peopleInput = document.getElementById('people');
     const dateInput = document.getElementById('date');
     const totalPriceEl = document.getElementById('total-price');
@@ -747,34 +736,17 @@
   return lines.join('\n\n'); // lege regel ertussen voor extra ruimte
 }
 
-    function buildEmailBody(data) {
-      const intro = `Ik wil graag een vaartocht boeken tijdens het Amsterdam Light Festival op ${data.date || '[datum]'} om ${data.time || '[tijd]'} met ${data.people || '[aantal]'} personen.`;
-      const extra = [
-        data.name ? `Naam: ${data.name}` : null,
-        data.phone ? `Telefoon: ${data.phone}` : null,
-        data.total ? `Totaal: ${formatCurrency(data.total)}` : null,
-        data.message ? `Bericht: ${data.message}` : null
-      ].filter(Boolean);
-
-      const bodyParts = [intro];
-      if (extra.length) bodyParts.push('', ...extra);
-      return bodyParts.join('\n');
-    }
-
     function encode(str) { return encodeURIComponent(str); }
 
-    function openWhatsAppOrFallback(msg, data) {
+    function openWhatsApp(msg) {
       const waURL = `https://wa.me/31653802957?text=${encode(msg)}`;
-      const mailBody = buildEmailBody(data);
-      const mailURL = `mailto:bookings@canalstartup.nl?subject=Boekingsaanvraag%20ALF25&body=${encode(mailBody)}`;
-
-      // Update fallback link for accessibility
-      fallbackEmail.setAttribute('href', mailURL);
       const opened = window.open(waURL, '_blank');
       if (!opened) window.location.href = waURL;
-      feedback.classList.remove('sr-only');
-      feedback.className = 'mt-3 text-sm text-black/70';
-      feedback.textContent = 'WhatsApp geopend? Zo niet: klik op “of e-mail”.';
+      if (feedback) {
+        feedback.classList.remove('sr-only');
+        feedback.className = 'mt-3 text-sm text-black/70';
+        feedback.textContent = 'WhatsApp geopend? Zo niet: stuur ons direct een appje op +31 6 53 80 29 57.';
+      }
     }
 
     function sanitizePeopleCount(value) {
@@ -879,7 +851,7 @@
       }
 
       const msg = buildMessage(data);
-      openWhatsAppOrFallback(msg, data);
+      openWhatsApp(msg);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- remove the email booking call-to-action from the booking form and sticky mobile bar
- drop the mail fallback logic so submissions only open WhatsApp and update the helper text
- update meta descriptions to mention only WhatsApp bookings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de65ed85848332aa0eb1159521fdea