### PR TITLE
Update booking form time slot labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
           <div class="absolute inset-0 flex items-center justify-center text-center p-4">
             <div class="bg-black/50 px-6 py-5 rounded-2xl max-w-xl">
               <h2 class="text-3xl md:text-5xl font-bold text-white">€59,95 p.p. all-in · 90 min</h2>
-              <p class="mt-2 text-lg text-white/90">Starttijden 17:30 · 19:30</p>
+              <p class="mt-2 text-lg text-white/90">Starttijden 17:30 – 19:00 · 19:30 – 21:00</p>
               <a href="#booking" class="mt-6 inline-block rounded-2xl bg-white text-black px-6 py-3 font-semibold">Boek nu</a>
             </div>
           </div>
@@ -440,7 +440,8 @@
             <div class="flex flex-col gap-1">
               <select class="rounded-xl border border-black/10 px-4 py-3" id="time" name="time" required>
                 <option value="">Kies tijdslot</option>
-                <option>17:30</option><option>19:30</option>
+                <option>17:30 – 19:00</option>
+                <option>19:30 – 21:00</option>
               </select>
               <p id="time-error" class="hidden text-sm text-red-600" data-error-for="time">Kies een tijdslot</p>
             </div>


### PR DESCRIPTION
## Summary
- update the booking hero and form time slot labels to show full ranges
- ensure guests select between 17:30 – 19:00 and 19:30 – 21:00

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de671ccb4c8332a1ba31551057a972