### PR TITLE
Remove footer booking and Instagram links

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,10 +530,6 @@
         <p class="text-sm text-black/60">© <span id="year"></span> A.L.F.25 – Amsterdam</p>
         <p class="text-xs text-black/50">© 2025 Varen Light Festival – Alle bedragen zijn exclusief btw</p>
       </div>
-      <div class="flex items-center justify-center md:justify-end gap-4 text-sm">
-        <a href="#booking" class="hover:underline">Boeken</a>
-        <a href="https://instagram.com/" target="_blank" rel="noopener" class="hover:underline">Instagram</a>
-      </div>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary
- remove the booking and Instagram links from the footer so only the copyright text remains

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de918548b48332ab38a98ca0820010