### PR TITLE
Adjust header spacing below festival dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,9 +178,9 @@
     Bij regen: kosteloos verplaatsen
   </div>
   <!-- Sticky top nav -->
-  <header class="sticky top-[28px] z-40 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-black/5">
-    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
-      <a href="#hero" class="flex flex-col items-start font-semibold tracking-tight">
+  <header class="sticky top-[28px] z-40 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-black/5 pb-2">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
+      <a href="#hero" class="flex flex-col items-start gap-1 font-semibold tracking-tight">
         <div class="flex items-center gap-2 text-xl">
           <img
             src="logo_with_spacing.svg"


### PR DESCRIPTION
## Summary
- add bottom padding to the sticky header and vertical padding to its content
- introduce vertical gap beneath the festival date label for clearer spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e79f9237a48332ac9a71557b8863a8