### PR TITLE
Update Open Graph image for WhatsApp sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,12 @@
   <!-- Open Graph / WhatsApp / Facebook -->
   <meta property="og:title" content="Canal Cruise & Light Festival 27 nov 2025 - 18 jan 2026" />
   <meta property="og:description" content="Gezellig met verse soep en glühwein · Jij regelt de mensen, wij de rest · Boek direct via WhatsApp." />
-  <meta property="og:image" content="https://varenlightfestival.nl/public/images/applogo.PNG" />
-  <meta property="og:image:width" content="1200" />
-  <meta property="og:image:height" content="630" />
+  <meta property="og:image" content="https://matthijshart.github.io/AmsterdamLightFestival/public/images/applogo.PNG" />
+  <meta property="og:image:secure_url" content="https://matthijshart.github.io/AmsterdamLightFestival/public/images/applogo.PNG" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="1024" />
+  <meta property="og:image:height" content="1024" />
+  <meta property="og:image:alt" content="A.L.F.25 applicatie pictogram" />
   <meta property="og:url" content="https://varenlightfestival.nl/" />
   <meta property="og:type" content="website" />
 
@@ -17,7 +20,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="A.L.F.25 – Canal Cruise & Light Festival" />
   <meta name="twitter:description" content="Gezellig met verse soep, glühwein en warme dekens · Jij regelt de mensen, wij de rest · Boek direct via WhatsApp." />
-  <meta name="twitter:image" content="https://matthijshart.github.io/AmsterdamLightFestival/public/share/alf25-share.png" />
+  <meta name="twitter:image" content="https://matthijshart.github.io/AmsterdamLightFestival/public/images/applogo.PNG" />
   <title>A.L.F.25 – Canal Cruise & Light Festival</title>
 
   <link rel="icon" type="image/svg+xml" href="logo_with_spacing.svg" />


### PR DESCRIPTION
## Summary
- point the Open Graph image metadata to the applogo asset served from GitHub Pages
- add secure URL, type, dimensions, and alt text to improve social previews
- align the Twitter card image with the same logo asset

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e92905c0788332ae349daf8813fd5f